### PR TITLE
Adds support for `#[derive]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 0.4.1
+* Added support for annotating error types with `#[derive]` attribute to derive extra traits.
 
 # 0.4.0
 * Fixed variant name construction: Did not actually consider each path segment as a proper word.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.4.1
+
 # 0.4.0
 * Fixed variant name construction: Did not actually consider each path segment as a proper word.
 * Cleaned up variant names: Now strips "Error" suffix if present.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "error_mancer"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "error_mancer_macros",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "error_mancer_macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "convert_case",
  "proc-macro2",

--- a/error_mancer/Cargo.toml
+++ b/error_mancer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error_mancer"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Quickly define custom error enums for a function."
 license = "MIT"
@@ -11,7 +11,7 @@ categories = ["rust-patterns"]
 keywords = ["macro", "attribute-macro", "error", "error-handling", "no-std"]
 
 [dependencies]
-error_mancer_macros = {path = "../error_mancer_macros", version="0.4.0"}
+error_mancer_macros = {path = "../error_mancer_macros", version="0.4.1"}
 
 [dev-dependencies]
 trybuild = "1"

--- a/error_mancer/src/lib.rs
+++ b/error_mancer/src/lib.rs
@@ -101,6 +101,28 @@
 //! }
 //! ```
 //!
+//! ## Deriving traits for generated enum
+//! You can annotate the function with `#[derive]` to derive traits for the generated enum.
+//! Note that the `#[derive]` macro must be used after the `errors` macro. (techically in `impl`
+//! blocks the order doesnt matter, but we recommend using `#[derive]` after `errors` for consistency.)
+//! ```rust
+//! # use error_mancer::prelude::*;
+//! # use thiserror::Error;
+//! # #[derive(Error, Debug, Clone)]
+//! # #[error("1")]
+//! # struct Err1;
+//!
+//! #[errors(Err1)]
+//! #[derive(Clone)]
+//! fn foo() -> Result<(), _> {
+//!     Ok(())
+//! }
+//!
+//! fn bar() {
+//!     let _ = foo().clone();
+//! }
+//! ```
+//!
 //! ## Specifics and Implementation Details
 //!
 //! ### Error Type Overwriting

--- a/error_mancer/tests/derive.rs
+++ b/error_mancer/tests/derive.rs
@@ -1,0 +1,27 @@
+use error_mancer::errors;
+use thiserror::Error;
+
+#[derive(Error, Clone, Debug)]
+#[error("err1")]
+struct Err1;
+
+#[errors(Err1)]
+#[derive(Clone)]
+fn foo() -> Result<(), _> {
+    Ok(())
+}
+
+fn bar() {
+    let _ = foo().clone();
+}
+
+struct Bar;
+
+#[errors]
+impl Bar {
+    #[errors(Err1)]
+    #[derive(Clone)]
+    fn bar(&self) -> Result<(), _> {
+        Ok(())
+    }
+}

--- a/error_mancer_macros/Cargo.toml
+++ b/error_mancer_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error_mancer_macros"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT"
 description = "proc macro for error_mancer"


### PR DESCRIPTION
closes #1 
```rust
#[errors(...)]
#[derive(Clone)]
fn foo() -> Result<(), _> { ... }
```